### PR TITLE
feat: added kms permissions to lambda execution

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -24,6 +24,17 @@ data "aws_iam_policy_document" "rotation" {
       "arn:aws:lambda:::*",
     ]
   }
+  statement {
+    actions = [
+      "kms:Describe*",
+      "kms:List*",
+      "kms:Get*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*"
+    ]
+    resources = [var.existing_kms_key_alias != "" ? data.aws_kms_alias.default.0.target_key_arn : "*"]
+  }
 
   statement {
     actions = [
@@ -129,7 +140,7 @@ resource "aws_lambda_function" "lambda" {
   environment {
     variables = { #https://docs.aws.amazon.com/general/latest/gr/rande.html#asm_region
       SECRETS_MANAGER_ENDPOINT = var.secretsmanager_vpc_endpoint == "" ? "https://secretsmanager.${data.aws_region.current.name}.amazonaws.com" : var.secretsmanager_vpc_endpoint
-      EXCLUDE_CHARACTERS = ",%<>+*&-=$[](){}~!;:/@\"'\\|`#"
+      EXCLUDE_CHARACTERS       = ",%<>+*&-=$[](){}~!;:/@\"'\\|`#"
     }
   }
 }


### PR DESCRIPTION
Added basic kms permissions to lambda execution role

Was failing due to permission error [[ref]](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Flambda-rds-rotation-function-dev-dagster/log-events/2022$252F05$252F12$252F$255B$2524LATEST$255Dc96b5be1bd7540089939e8cddbd3619a)

[Related PR](https://github.com/humn-ai/tf-humn-iac-live/pull/1006)