### PR TITLE
HT-8353 chore: use aws_iam_role_policy_attachment instead of aws_iam_policy_attachment

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -64,17 +64,15 @@ data "aws_iam_policy_document" "rotation" {
 
 // Lambda Policies
 
-resource "aws_iam_policy_attachment" "basic_execution" {
+resource "aws_iam_role_policy_attachment" "basic_execution" {
   count      = var.enabled ? 1 : 0
-  name       = "lambda-rds-rotation-execution-policy-${var.environment}-${var.name}"
-  roles      = [aws_iam_role.lambda.0.name]
+  role       = aws_iam_role.lambda.0.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-resource "aws_iam_policy_attachment" "vpc_execution" {
+resource "aws_iam_role_policy_attachment" "vpc_execution" {
   count      = var.enabled ? 1 : 0
-  name       = "lambda-rds-rotation-execution-policy-${var.environment}-${var.name}"
-  roles      = [aws_iam_role.lambda.0.name]
+  role      = aws_iam_role.lambda.0.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -30,4 +30,7 @@ resource "aws_secretsmanager_secret_version" "default" {
     "port": "${lookup(var.secret_config, "port", "")}"
   }
   EOF
+  lifecycle {
+    ignore_changes = [secret_string, version_id]
+  }
 }


### PR DESCRIPTION
## Jira
- [HT-8353](https://humnai.atlassian.net/browse/HT-8353)
## Changes
- chore: use aws_iam_role_policy_attachment instead of aws_iam_policy_attachment
- chore: Add ignore_changes to secrets string change after rotation
